### PR TITLE
Changes H1 alignment to left, from centre

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## `v.0.3.0`
+
+Titles are now rendered left-aligned.  Previously centre-aligned.  Centre alignment didn't look great
+in wide terminals.  The heading looked detected from the content.  Left alignment ensures the heading
+appears above the content.
+
+## `v.0.2.0`
+
+We have added unit tests.
+
 ## `v.0.1.0`
 
 Big Bang!
@@ -26,5 +36,5 @@ Syntax highlighting is available if you have [Bat](https://github.com/sharkdp/ba
 
 ```
 
-> ⚠️ Warning ⚠️  
+> ⚠️ Warning ⚠️
 > We used [Nerd Fonts](https://www.nerdfonts.com/) when rendering to the console.  If your font doesn't support the fall range of characters some elements may not render correctly.

--- a/src/Markdown.Console.Tests/MarkdownConsole.Tests/MarkdownConsoleHeaderTests.cs
+++ b/src/Markdown.Console.Tests/MarkdownConsole.Tests/MarkdownConsoleHeaderTests.cs
@@ -5,16 +5,15 @@ namespace Markdown.Console.Tests;
 
 public partial class MarkdownConsoleTests
 {
-    [Fact(Skip = "We need to set TestConole to a fixed width to make this test deterministic.")]
+    [Fact(Skip = "Flakey || Test results depend on underlying console width")]
     public void Given_markdown_with_header_level_1_block_should_return_correct_ansi_escaped_string()
     {
-        var expected =
-            @"                 [38;5;5m  _   _                      _               [0m
-                 [38;5;5m | | | |   ___    __ _    __| |   ___   _ __ [0m
-                 [38;5;5m | |_| |  / _ \  / _` |  / _` |  / _ \ | '__|[0m
-                 [38;5;5m |  _  | |  __/ | (_| | | (_| | |  __/ | |   [0m
-                 [38;5;5m |_| |_|  \___|  \__,_|  \__,_|  \___| |_|   [0m
-                 [38;5;5m                                             [0m
+        var expected = @$"{AnsiEscape}[38;5;5m  _   _                      _               {AnsiEscape}[0m
+{AnsiEscape}[38;5;5m | | | |   ___    __ _    __| |   ___   _ __ {AnsiEscape}[0m
+{AnsiEscape}[38;5;5m | |_| |  / _ \\  / _` |  / _` |  / _ \\ | '__|{AnsiEscape}[0m
+{AnsiEscape}[38;5;5m |  _  | |  __/ | (_| | | (_| | |  __/ | |   {AnsiEscape}[0m
+{AnsiEscape}[38;5;5m |_| |_|  \\___|  \\__,_|  \\__,_|  \\___| |_|   {AnsiEscape}[0m
+{AnsiEscape}[38;5;5m                                             {AnsiEscape}[0m
 ";
         var actual = new TestConsole()
             .Write("# Header")

--- a/src/Markdown.Console/AnsiRenderer.cs
+++ b/src/Markdown.Console/AnsiRenderer.cs
@@ -165,7 +165,7 @@ public class AnsiRenderer
 
         if (block.Level == 1)
         {
-            buffer.Write(new FigletText(rawContent).Alignment(Justify.Center).Color(Color.Purple));
+            buffer.Write(new FigletText(rawContent).Alignment(Justify.Left).Color(Color.Purple));
             return;
         }
 

--- a/src/Markdown.Console/Markdown.Console.csproj
+++ b/src/Markdown.Console/Markdown.Console.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Markdown.Console</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>David Rushton</Authors>
     <Company>David Rushton Dev</Company>
     <Description>


### PR DESCRIPTION
Centre aligned text can leave the header disconnected from the content.  This is especially true if when viewed in a wide terminal.

Switching to left aligned ensures the title appears the content.