### PR TITLE
Dr/fix nuget icons

### DIFF
--- a/docs/markdown-console/release-notes.md
+++ b/docs/markdown-console/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## `v1.3.2`
+
+We've added our logo to NuGet.
+
 ## `v1.3.1`
 
 Bug fix.  We failed to print the final character when falling back to plain text.

--- a/src/markdown-console/Morello.MarkdownConsole/Morello.MarkdownConsole.csproj
+++ b/src/markdown-console/Morello.MarkdownConsole/Morello.MarkdownConsole.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
 
     <PackageId>Morello.MarkdownConsole</PackageId>
-    <Version>1.3.1</Version>
-    <icon>cherry-64.png</icon>
+    <Version>1.3.2</Version>
+    <PackageIcon>cherry-64.png</PackageIcon>
     <Company>Morello</Company>
     <Authors>David Rushton</Authors>
     <Title>Markdown Console</Title>
@@ -34,10 +34,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="" />
-    <None Include="..\..\..\LICENSE" Pack="true" PackagePath="" />
-
-    <None Include="..\images\cherry-64.png" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\..\LICENSE" Pack="true" PackagePath="\" />
+    <None Include="..\images\cherry-64.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/markdown-console/README.md
+++ b/src/markdown-console/README.md
@@ -1,4 +1,4 @@
-# ![cherry icon](./images/cherry-64.png) Markdown Console
+# ![cherry icon](https://raw.githubusercontent.com/David-Rushton/morello.markdown/main/src/markdown-console/images/cherry-64.png) Markdown Console
 
 [![Console PR Build and Test](https://github.com/David-Rushton/morello.markdown/actions/workflows/markdown_console_on_pull_request_to_main.yml/badge.svg)](https://github.com/David-Rushton/morello.markdown/actions/workflows/markdown_console_on_pull_request_to_main.yml)
 [![Console Publish to NuGet](https://github.com/David-Rushton/morello.markdown/actions/workflows/markdown_console_on_push_to_main.yml/badge.svg)](https://github.com/David-Rushton/morello.markdown/actions/workflows/markdown_console_on_push_to_main.yml)


### PR DESCRIPTION
Changes in this PR

- README now servers logo from NuGet trusted domain
https://docs.microsoft.com/en-gb/nuget/nuget-org/package-readme-on-nuget-org#allowed-domains-for-images-and-badges
Fixes #16 

- We now use `PackageIcon` instead of `Icon` in `.csproj`
This should add our icon to NuGet search
